### PR TITLE
Proper fix for sliding disabled in constant speed mode

### DIFF
--- a/Player/Custom/PlayerCustom.gd
+++ b/Player/Custom/PlayerCustom.gd
@@ -199,12 +199,12 @@ func custom_move_and_slide(p_linear_velocity: Vector2, p_up_direction: Vector2, 
 				else:
 					on_wall = true
 			
-			if on_floor:
+			if not on_floor:
 				sliding_enabled = true
 			
 			# compute motion
 			# constant speed
-			if on_floor and constant_speed_on_floor and can_apply_constant_speed:
+			if on_floor and sliding_enabled and constant_speed_on_floor and can_apply_constant_speed:
 					var slide: Vector2 = collision.remainder.slide(collision.normal).normalized()
 					if not slide.is_equal_approx(Vector2.ZERO):
 						motion = slide * (original_motion.slide(p_up_direction).length() - collision.travel.slide(p_up_direction).length())  # alternative use original_motion.length() to also take account of the y value


### PR DESCRIPTION
I had made a typo in #2 and didn't realize it was not doing what it was supposed to. Sliding can only be forced when not on floor (in order to always keep the character stabilized when grounded).

Added a proper fix for what #2 was trying to fix: sliding could still occur in constant speed mode in the first iteration, when sliding is supposed to be disabled.

Helps with this bug:
![move_and_slide_bump_wall](https://user-images.githubusercontent.com/1075032/123860445-c4228980-d8da-11eb-8286-27fc6149fb11.gif)